### PR TITLE
Open for all major14 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbi-app",
-  "version": "4.0.0",
+  "version": "5.0.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pbi-app",
-  "version": "5.0.1",
+  "version": "4.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/projects/ngx-powerbi/package.json
+++ b/projects/ngx-powerbi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-powerbi",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "TypeScript library for embedding Power BI assets (reports/dashboards/tiles) in your application. This TypeScript library is built on top of the official powerbi-client library provided by Microsoft.",
   "license": "MIT",
   "repository": {
@@ -30,8 +30,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "@angular/common": "^14.1.0",
-    "@angular/core": "^14.1.0",
+    "@angular/common": "^14.0.0",
+    "@angular/core": "^14.0.0",
     "powerbi-client": "^2.19.1"
   }
 }


### PR DESCRIPTION
The upgrade to angular 14 locked all clients to use angular greater than 14.1, this can lead to conflicts in version resolution
https://github.com/ramandeep-singh-1983/ngx-powerbi/pull/67/files

For example, ngx-bootstrap locks user to 14.0.x versions of angular, leading to a conflict between the packages.

https://github.com/valor-software/ngx-bootstrap/blob/0380c3c420225e2f0e84d8ae07808f7c0879df95/package.json#L63

I do not see the need to update lock-files, this should strictly be to open up for supported versions so people who depend on the package can stop using --legacy-peer-deps